### PR TITLE
always include server name as a top level param

### DIFF
--- a/lib/hubcap/server.rb
+++ b/lib/hubcap/server.rb
@@ -5,10 +5,14 @@ class Hubcap::Server < Hubcap::Group
 
   def initialize(parent, name, options = {}, &blk)
     super(parent, name, &blk)
+    hist = history.join('.')
+
+    # only set the server_name if it's not already set
+    param('server_name' => hist) if params['server_name'].nil?
+
     # If name is an IP, or is not in hosts hash, use name as address
     # Otherwise, dereference it from the hash and assign it
     unless @address = options[:address]
-      hist = history.join('.')
       @address = lookup(hist)
       @address = lookup(name)  if @address == hist
     end

--- a/test/unit/test_server.rb
+++ b/test/unit/test_server.rb
@@ -55,15 +55,28 @@ class Hubcap::TestServer < Test::Unit::TestCase
         role('baseline')
         server('test') {
           role('test::server')
-          param('foo' => 1, 'bar' => 2)
+          param('foo' => '1', 'bar' => '2')
         }
       }
     }
     hash = YAML.load(hub.servers.first.yaml)
     assert_equal({ 'baseline' => nil, 'test::server' => nil }, hash['classes'])
     assert_equal(['classes', 'parameters'], hash.keys.sort)
-    assert_equal(['bar', 'foo'], hash['parameters'].keys.sort)
-    assert_equal([1, 2], hash['parameters'].values.sort)
+    assert_equal(['bar', 'foo', 'server_name'], hash['parameters'].keys.sort)
+    assert_equal(['1', '2', 'everything.test'], hash['parameters'].values.sort)
+  end
+
+  def test_yaml_server_name
+    hub = Hubcap.hub {
+      group('everything') {
+        role('baseline')
+        param('server_name' => 'do not overwrite')
+        server('test')
+      }
+    }
+    hash = YAML.load(hub.servers.first.yaml)
+    assert_equal(['server_name'], hash['parameters'].keys)
+    assert_equal(['do not overwrite'], hash['parameters'].values)
   end
 
 


### PR DESCRIPTION
this will allow the ability to treat the top level param of 'server_name' in a similar way as a fact which will allow conditional logic on the name
