### PR TITLE
absorb properly emits correct stack trace

### DIFF
--- a/lib/hubcap/group.rb
+++ b/lib/hubcap/group.rb
@@ -34,7 +34,7 @@ class Hubcap::Group
     p += '.rb'  unless File.exists?(p)
     raise("File not found: #{path}")  unless File.exists?(p)
     code = IO.read(p)
-    eval(code)
+    eval(code, binding, p)
   end
 
 


### PR DESCRIPTION
when there is an error in eval, the stack trace now properly includes the location of the error in the eval block
